### PR TITLE
Update auto-publish.yml

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   main:
     name: Build, Validate and Deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2


### PR DESCRIPTION
update workflow to use ubuntu-latest

This update is based on the error message (see below) received on my latest PR.

Error message:
  $ bikeshed update
    Bikeshed now requires Python 3.9; you are on 3.8.10.
        If you're seeing this message in your CI run, you are
        likely specifying an old OS; try `ubuntu-latest`.
        If you're seeing this on the command line, see the docs
        for instructions:
        https://speced.github.io/bikeshed/#installing
  Command `bikeshed update` failed with exit code: 1.