### PR TITLE
Fix typo in .pr-preview.json

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,4 +1,4 @@
 {
-    "src_file": "requestStorageAccessForOrigin.bs",
+    "src_file": "index.bs",
     "type": "bikeshed"
 }


### PR DESCRIPTION
The config currently refers to a non-existent file.